### PR TITLE
remove example tag

### DIFF
--- a/src/cmd-send.c
+++ b/src/cmd-send.c
@@ -50,7 +50,7 @@ client_send (int argc, char *argv[])
 
   event = riemann_event_new ();
 
-  riemann_event_set_one (event, TAGS, "riemann-c-client", "example:send-events",
+  riemann_event_set_one (event, TAGS, "riemann-c-client",
                          NULL);
   riemann_event_set_one (event, ATTRIBUTES,
                          riemann_attribute_create ("x-client", "riemann-c-client"),


### PR DESCRIPTION
All events are being tagged "example:send-events".
The other automatic tag and attribute is fine, I guess :)

Event #0:
  time  = 1425052789 - Fri Feb 27 16:59:49 2015
  state = ok
  service = total users
  host = (null)
  description = (null)
  ttl = 120.000000
  metric_sint64 = 3
  metric_f = 3.000000
  tags = [ riemann-c-client example:send-events ]
  attributes = {
    x-client = riemann-c-client
  }