### PR TITLE
using PROTOBUF_C_CFLAGS environment variable

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -106,7 +106,7 @@ check_libriemann_srcs		= \
 bin_PROGRAMS			= \
 	src/riemann-client
 
-src_riemann_client_CFLAGS	= $(AM_CFLAGS) $(JSON_C_CFLAGS)
+src_riemann_client_CFLAGS	= $(AM_CFLAGS) $(JSON_C_CFLAGS) ${PROTOBUF_C_CFLAGS}
 src_riemann_client_LDADD	= $(JSON_C_LIBS) $(LDADD)
 src_riemann_client_EXTRA_DIST	= \
 	src/cmd-send.c		  \


### PR DESCRIPTION
I set the PROTOBUF_C_CFLAGS environment variable before running configure, but the value was not being used when building riemann-client.c