### PR TITLE
HAVE_VERSIONING: use #if not #ifdef

### DIFF
--- a/lib/riemann/client.c
+++ b/lib/riemann/client.c
@@ -224,7 +224,7 @@ riemann_client_connect_1_0 (riemann_client_t *client,
   return riemann_client_connect (client, type, hostname, port);
 }
 
-#ifdef HAVE_VERSIONING
+#if HAVE_VERSIONING
 __asm__(".symver riemann_client_connect_1_0,riemann_client_connect@RIEMANN_C_1.0");
 #endif
 
@@ -259,7 +259,7 @@ riemann_client_create_1_0 (riemann_client_type_t type,
   return riemann_client_create (type, hostname, port);
 }
 
-#ifdef HAVE_VERSIONING
+#if HAVE_VERSIONING
 __asm__(".symver riemann_client_create_1_0,riemann_client_create@RIEMANN_C_1.0");
 #endif
 


### PR DESCRIPTION
Since HAVE_VERSIONING is defined to 0, "#if" works but "#ifdef" doesn't.

On non-ELF systems (e.g., darwin)  this fixes the following error:
```
  <inline asm>:1:1: error: unknown directive
  .symver riemann_client_connect_1_0,riemann_client_connect@RIEMANN_C_1.0
```